### PR TITLE
fix null _server: the private class field _server is never inited.

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -6,6 +6,7 @@ license "WTFPL"
 dependency "protobuf" version="~>0.6.2"
 dependency "automem" version="~>0.6.2"
 dependency "grpc-d-interop" version="~>0.0.1"
+dependency "emsi_containers" version="~>0.9.0"
 configuration "library" {
 	targetType "library"
 	dflags "-dip25" "-dip1000"

--- a/source/grpc/common/byte_buffer.d
+++ b/source/grpc/common/byte_buffer.d
@@ -96,7 +96,8 @@ struct ByteBuffer {
             reader = reader.init;
         }
         
-        return slice_to_type!(ubyte[])(slice);
+	ubyte[] r = slice_to_type!(ubyte[])(slice);
+        return r;
     }
 
 

--- a/source/grpc/common/call.d
+++ b/source/grpc/common/call.d
@@ -50,13 +50,15 @@ struct CallDetails {
     @property string method() @trusted {
         mutex.lock;
         scope(exit) mutex.unlock;
-        return slice_to_string(handle.method); 
+	string r = slice_to_string(handle.method); 
+        return r;
     }
 
     @property string host() @trusted {
         mutex.lock;
         scope(exit) mutex.unlock;
-        return slice_to_string(handle.host);
+	string r = slice_to_string(handle.host);
+        return r;
     }
 
     @property uint flags() {

--- a/source/grpc/core/package.d
+++ b/source/grpc/core/package.d
@@ -22,7 +22,7 @@ void init() {
 }
 
 void shutdown() {
-    grpc_shutdown_blocking();
+    grpc_shutdown();
 }
 
 string g_stands_for() {

--- a/source/grpc/server/builder.d
+++ b/source/grpc/server/builder.d
@@ -24,7 +24,8 @@ class ServerBuilder {
         return _port;
     }
 
-    void register(T)() {
+    void register(T)(Server server) {
+	_server = server;
         _server.registerService!T();
     }
 

--- a/source/grpc/server/package.d
+++ b/source/grpc/server/package.d
@@ -83,18 +83,23 @@ class Server
     }
 
     import core.atomic;
+    import std.stdio;
     void wait() {
         foreach(service; services.keys) {
             services[service].kickstart();
         }
 
         while (atomicLoad(_run)) {
+		writeln(services.keys);  // print out some wrong dict value of other (un-related) parts of the program
             
+	/* https://forum.dlang.org/thread/duetqujuoceancqtjlar@forum.dlang.org
+	   comment out this loop, as it's not actually doing much, and the SIGSEGV goes away
             foreach(service; services) {
                 if (service.runners == 0) {
                     ERROR!"service is DEAD!";
                 }
             }
+	    */
 
             Thread.sleep(1.seconds);
         }

--- a/source/grpc/server/package.d
+++ b/source/grpc/server/package.d
@@ -12,13 +12,17 @@ import google.rpc.status;
 import core.thread;
 import core.lifetime;
 
+import containers.hashmap;  // emsi_containers
+
 class Server 
 {
     private {
         shared(Mutex) mutex;
         SharedResource _server;
         shared(CompletionQueue!"Next")[] _registeredCqs;
-        ServiceHandlerInterface[string] services;
+	// https://forum.dlang.org/thread/vkkwysusmnivkooglgwd@forum.dlang.org
+	// life is too short to debug dlang built-in AA to right, let's just use HashMap from emsi_containers
+        HashMap!(string, ServiceHandlerInterface) services;
         bool started;
         shared bool _run;
 
@@ -90,16 +94,16 @@ class Server
         }
 
         while (atomicLoad(_run)) {
-		writeln(services.keys);  // print out some wrong dict value of other (un-related) parts of the program
+	    writeln(services.keys);  // print out some wrong dict value of other (un-related) parts of the program
             
 	/* https://forum.dlang.org/thread/duetqujuoceancqtjlar@forum.dlang.org
-	   comment out this loop, as it's not actually doing much, and the SIGSEGV goes away
+	   when in trouble, comment out this loop, as it's not actually doing much, and the SIGSEGV goes away
+	    */
             foreach(service; services) {
                 if (service.runners == 0) {
                     ERROR!"service is DEAD!";
                 }
             }
-	    */
 
             Thread.sleep(1.seconds);
         }


### PR DESCRIPTION
-- fix null _server: the private class field _server is never inited.
-- http://grpc.github.io/grpc/core/grpc_8h.html#aceedc7178f15ebef5f518ca180938a20

GRPCAPI void grpc_shutdown_blocking	(	void 		)	
DEPRECATED.

Recommend to use grpc_shutdown only

-- fix DMD64 D Compiler v2.104.0 new compiling error

-- life is too short to debug dlang built-in AA to right, let's just use HashMap from emsi_containers.
Fixed the problem found here:
https://forum.dlang.org/thread/duetqujuoceancqtjlar@forum.dlang.org